### PR TITLE
Globals

### DIFF
--- a/data_conversion.c
+++ b/data_conversion.c
@@ -591,6 +591,7 @@ static int luasandbox_lua_pair_to_array(HashTable *ht, lua_State *L,
 	str = lua_tolstring(L, -1, &length);
 	if ( str == NULL ) {
 		// Only strings and integers may be used as keys
+		zval_ptr_dtor(&value);
 		char *message;
 		spprintf(&message, 0, "Cannot use %s as an array key when passing data from Lua to PHP",
 			lua_typename(L, lua_type(L, -2))
@@ -619,6 +620,7 @@ static int luasandbox_lua_pair_to_array(HashTable *ht, lua_State *L,
 #endif
 	{
 		// Collision, probably the key is an integer-like string
+		zval_ptr_dtor(&value);
 		char *message;
 		spprintf(&message, 0, "Collision for array key %s when passing data from Lua to PHP", str );
 		zval_ptr_dtor(&value);
@@ -636,6 +638,7 @@ static int luasandbox_lua_pair_to_array(HashTable *ht, lua_State *L,
 add_int_key:
 	if (zend_hash_index_exists(ht, zn)) {
 		// Collision, probably with a integer-like string
+		zval_ptr_dtor(&value);
 		char *message;
 		spprintf(&message, 0, "Collision for array key %" PRId64 " when passing data from Lua to PHP",
 			(int64_t)zn

--- a/data_conversion.c
+++ b/data_conversion.c
@@ -591,7 +591,6 @@ static int luasandbox_lua_pair_to_array(HashTable *ht, lua_State *L,
 	str = lua_tolstring(L, -1, &length);
 	if ( str == NULL ) {
 		// Only strings and integers may be used as keys
-		zval_ptr_dtor(&value);
 		char *message;
 		spprintf(&message, 0, "Cannot use %s as an array key when passing data from Lua to PHP",
 			lua_typename(L, lua_type(L, -2))
@@ -620,7 +619,6 @@ static int luasandbox_lua_pair_to_array(HashTable *ht, lua_State *L,
 #endif
 	{
 		// Collision, probably the key is an integer-like string
-		zval_ptr_dtor(&value);
 		char *message;
 		spprintf(&message, 0, "Collision for array key %s when passing data from Lua to PHP", str );
 		zval_ptr_dtor(&value);
@@ -638,7 +636,6 @@ static int luasandbox_lua_pair_to_array(HashTable *ht, lua_State *L,
 add_int_key:
 	if (zend_hash_index_exists(ht, zn)) {
 		// Collision, probably with a integer-like string
-		zval_ptr_dtor(&value);
 		char *message;
 		spprintf(&message, 0, "Collision for array key %" PRId64 " when passing data from Lua to PHP",
 			(int64_t)zn

--- a/luasandbox_types.h
+++ b/luasandbox_types.h
@@ -59,7 +59,8 @@ typedef struct {
 #endif /*CLOCK_REALTIME*/
 
 ZEND_BEGIN_MODULE_GLOBALS(luasandbox)
-	HashTable * allowed_globals;
+	/* Stored as a value rather than a pointer to avoid segfaults. Inspired by https://github.com/php/php-src/blob/master/ext/pcre/php_pcre.c.*/
+	HashTable allowed_globals;
 	long active_count;
 ZEND_END_MODULE_GLOBALS(luasandbox)
 
@@ -145,4 +146,3 @@ static inline php_luasandboxfunction_obj *php_luasandboxfunction_fetch_object(ze
 #endif
 
 #endif /*LUASANDBOX_TYPES_H*/
-

--- a/php_luasandbox.h
+++ b/php_luasandbox.h
@@ -1,4 +1,3 @@
-
 #ifndef PHP_LUASANDBOX_H
 #define PHP_LUASANDBOX_H
 
@@ -11,6 +10,7 @@
 
 /* alloc.c */
 
+#define PHP_LUASANDBOX_INI_ALLOWED_GLOBALS "luasandbox.allowed_globals"
 
 lua_State * luasandbox_alloc_new_state(php_luasandbox_alloc * alloc, php_luasandbox_obj * sandbox);
 void luasandbox_alloc_delete_state(php_luasandbox_alloc * alloc, lua_State * L);
@@ -62,6 +62,7 @@ PHP_METHOD(LuaSandbox, getProfilerFunctionReport);
 PHP_METHOD(LuaSandbox, callFunction);
 PHP_METHOD(LuaSandbox, wrapPhpFunction);
 PHP_METHOD(LuaSandbox, registerLibrary);
+PHP_METHOD(LuaSandbox, allowedGlobals);
 
 PHP_METHOD(LuaSandboxFunction, __construct);
 PHP_METHOD(LuaSandboxFunction, call);
@@ -142,4 +143,3 @@ int luasandbox_attach_trace(lua_State * L);
 void luasandbox_push_structured_trace(lua_State * L, int level);
 
 #endif	/* PHP_LUASANDBOX_H */
-


### PR DESCRIPTION
Make allowed Lua globals configurable from php.ini
    
Add luasandbox.allowed_globals setting to php.ini.
    
Its default value is "assert,error,getfenv,getmetatable,\
ipairs,next,pairs,rawequal,rawget,rawset,select,setfenv,\
setmetatable,tonumber,type,unpack,_G,_VERSION,string,table,\
math,os,debug"--as was set by luasandbox_allowed_globals[].
    
This setting is split by commas, the chunks are trimmed and
saves as the LUASANDBOX_G(allowed_globals), which is now
HashTable and not HashTable*.
    
luasandbox_lib_register() uses this setting to filter allowed globals
via the new function global_allowed().
    
The code that was previously forming the whitelist is removed.
   
The list of allowed globals is returned by the new static method
LuaSandbox::allowedGlobals().