### PR TITLE
Libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,10 @@ running untrusted Lua 5.1 code from within PHP, which will generally
 be faster than shelling out to a Lua binary and using inter-process
 communication.
 
+This is a fork created for traditio.wiki.
+
+What's new:
+ - Added luasandbox.allowed_globals to php.ini and LuaSandbox::allowedGlobals() method
+ - Added luasandbox.additional_libraries to php.ini and LuaSandbox::additionalLibraries() method
+
 For more details see <https://www.mediawiki.org/wiki/LuaSandbox>.

--- a/docbook/book.xml
+++ b/docbook/book.xml
@@ -46,6 +46,7 @@
  </preface>
 
  &reference.luasandbox.setup;
+ &reference.luasandbox.ini; 
  <!-- &reference.luasandbox.constants; -->
  &reference.luasandbox.differences;
  &reference.luasandbox.examples;

--- a/docbook/configure.xml
+++ b/docbook/configure.xml
@@ -5,8 +5,8 @@
  &reftitle.install;
 
  <para>
-  &pecl.info;
-  <link xlink:href="&url.pecl.package;luasandbox">&url.pecl.package;luasandbox</link>
+  To enable luasandbox, run <option role="configure">phpenmod luasandbox</option>
+  and restart PHP service.
  </para>
 
 </section>

--- a/docbook/ini.xml
+++ b/docbook/ini.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<section xml:id="apcu.configuration" xmlns="http://docbook.org/ns/docbook">
+ &reftitle.runtime;
+ &extension.runtime;
+	 <para>
+	 	luasandbox for traditio.wiki offers the following configuration settings:
+	 </para>
+	<table>
+		<title>APCu configuration options</title>
+		<tgroup cols="4">
+			<thead>
+				<row>
+					<entry>&Name;</entry>
+					<entry>&Default;</entry>
+					<entry>&Changeable;</entry>
+					<entry>&Changelog;</entry>
+				</row>
+			</thead>
+			<tbody>
+				<row>
+					<entry><link linkend="ini.luasandbox.additional_libraries">luasandbox.additional_libraries</link></entry>
+					<entry>""</entry>
+					<entry>PHP_INI_SYSTEM</entry>
+					<entry></entry>
+				</row>
+				<row>
+					<entry><link linkend="ini.luasandbox.allowed_globals">luasandbox.allowed_globals</link></entry>
+						<entry>"assert,error,getfenv,getmetatable,ipairs,next,pairs,rawequal,rawget,rawset,select,setfenv,setmetatable,tonumber,type,unpack,_G,_VERSION,string,table,math,os,debug"</entry>
+					<entry>PHP_INI_SYSTEM</entry>
+					<entry></entry>
+				</row>
+			</tbody>
+		</tgroup>
+	</table>
+
+	&ini.descriptions.title;
+ 	<para>
+	<variablelist>
+		<varlistentry xml:id="luasandbox.additional_libraries">
+			<term>
+				<parameter>luasandbox.additional_libraries</parameter>
+				<type>string</type>
+			</term>
+			<listitem>
+				<para>
+					<literal>luasandbox.additional_libraries</literal> can be used to load additional Lua C libraries,
+					in the following form:
+					<literal>lib1=absolute path to .so file 1:lib2=absolute path to .so file 2</literal>,
+					e.g. <literal>rex_pcre=/usr/lib/x86_64-linux-gnu/lua/5.1/rex_pcre.so</literal> means that PHP engine
+					will attempt to load /usr/lib/x86_64-linux-gnu/lua/5.1/rex_pcre.so library,
+					call the initialization function <literal>luaopen_rex_pcre()</literal> and make the library available
+					under global name <literal>rex_pcre</literal>.
+				</para>
+				<para>
+					Note that the additional libraries will be filtered according to
+					<literal><link linkend="ini.luasandbox.allowed_globals">luasandbox.allowed_globals</link></literal>,
+					so that they have to be enabled there as well.
+				</para>
+			</listitem>
+		</varlistentry>
+		<varlistentry xml:id="luasandbox.allowed_globals">
+			<term>
+				<parameter>luasandbox.allowed_globals</parameter>
+				<type>string</type>
+			</term>
+			<listitem>
+				<para>
+					<literal>luasandbox.allowed_globals</literal> can be used to selecively enable and disable Lua globals.
+					Globals allowed by default are <literal>assert, error, getfenv, getmetatable, ipairs, next, pairs,
+					rawequal, rawget, rawset, select, setfenv, setmetatable, tonumber, type, unpack, _G, _VERSION, string,
+					table, math, os, debug</literal>.
+					Great care should be exercised while expanding this list, as it is a security risk.
+				</para>
+			</listitem>
+		</varlistentry>
+	</section>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/docbook/luasandbox/additionallibraries.xml
+++ b/docbook/luasandbox/additionallibraries.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<refentry xml:id="luasandbox.additionallibraries" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>LuaSandbox::additionalLibraries</refname>
+  <refpurpose>Return a list of successfully loaded additional Lua C libraries</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>array</type><methodname>LuaSandbox::additionalLibraries</methodname>
+  </methodsynopsis>
+  <para>
+   Returns a list of successfully loaded additional Lua C libraries as a numbered array.
+  </para>
+  <para>
+   For more information about loading additional libraries,
+   see <parametername><link linkend="ini.luasandbox.additional_libraries">luasandbox.additional_libraries</link></parametername>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns a numbered <type>array</type> of Lua additional libraries' global names, which may be empty.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Listing additional libraries</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// List libraries
+$libs = LuaSandbox::additionalLibraries();
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/docbook/luasandbox/allowedglobals.xml
+++ b/docbook/luasandbox/allowedglobals.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<refentry xml:id="luasandbox.allowedglobals" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>LuaSandbox::allowedGlobals</refname>
+  <refpurpose>Return a list of allowed Lua globals</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>array</type><methodname>LuaSandbox::allowedGlobals</methodname>
+  </methodsynopsis>
+  <para>
+   Returns a list of allowed Lua global variables as a numbered array.
+  </para>
+  <para>
+   For more information about filtering allowed globals,
+   see <parametername><link linkend="ini.luasandbox.allowed_globals">luasandbox.allowed_globals</link></parametername>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns a numbered <type>array</type> of the names of allowed Lua global variables, which may be empty.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Listing allowed globals</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// List globals
+$libs = LuaSandbox::allowedGlobals();
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/library.c
+++ b/library.c
@@ -58,7 +58,6 @@ static zend_bool global_allowed( zend_string * global TSRMLS_DC) {
 #else
 	return zend_hash_exists( &LUASANDBOX_G(allowed_globals), global );
 #endif
-	return 1;
 }
 /* }}} */
 
@@ -95,6 +94,7 @@ void luasandbox_lib_register(lua_State * L TSRMLS_DC)
 	// Remove any globals that aren't in a whitelist. This is mostly to remove
 	// unsafe functions from the base library.
 	lua_pushnil(L);
+	zend_string * global;
 	while (lua_next(L, LUA_GLOBALSINDEX) != 0) {
 		const char * key;
 		size_t key_len;

--- a/library.c
+++ b/library.c
@@ -91,6 +91,18 @@ void luasandbox_lib_register(lua_State * L TSRMLS_DC)
 	luasandbox_lib_filter_table(L, luasandbox_allowed_debug_members);
 	lua_setglobal(L, "debug");
 
+	// Load additional libraries:
+	zend_string * lib_z;
+	zval * loader_z;
+	ZEND_HASH_FOREACH_STR_KEY_VAL(&LUASANDBOX_G(library_loaders), lib_z, loader_z)
+		lua_CFunction loader_ptr = Z_PTR_P(loader_z);
+		if ( loader_ptr ) {
+			lua_pushcfunction( L, loader_ptr );
+			lua_call( L, 0, 1 );
+			lua_setglobal( L, ZSTR_VAL(lib_z) );
+		}
+	ZEND_HASH_FOREACH_END();
+	
 	// Remove any globals that aren't in a whitelist. This is mostly to remove
 	// unsafe functions from the base library.
 	lua_pushnil(L);

--- a/luasandbox.c
+++ b/luasandbox.c
@@ -10,6 +10,9 @@
 
 #include "php.h"
 #include "php_ini.h"
+
+#include "ext/pcre/php_pcre.h"
+
 #include "ext/standard/info.h"
 #include "zend_exceptions.h"
 #include "php_luasandbox.h"
@@ -108,6 +111,9 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO(arginfo_luasandbox_allowedGlobals, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO(arginfo_luasandbox_additionalLibraries, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_luasandbox_loadString, 0, 0, 1)
 	ZEND_ARG_INFO(0, code)
 	ZEND_ARG_INFO(0, chunkName)
@@ -194,6 +200,7 @@ const zend_function_entry luasandbox_functions[] = {
 const zend_function_entry luasandbox_methods[] = {
 	PHP_ME(LuaSandbox, getVersionInfo, arginfo_luasandbox_getVersionInfo, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME(LuaSandbox, allowedGlobals, arginfo_luasandbox_allowedGlobals, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(LuaSandbox, additionalLibraries, arginfo_luasandbox_additionalLibraries, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)	
 	PHP_ME(LuaSandbox, loadString, arginfo_luasandbox_loadString, 0)
 	PHP_ME(LuaSandbox, loadBinary, arginfo_luasandbox_loadBinary, 0)
 	PHP_ME(LuaSandbox, setMemoryLimit, arginfo_luasandbox_setMemoryLimit, 0)
@@ -300,7 +307,7 @@ static void register_allowed_globals( HashTable *table, const char *list TSRMLS_
 }
 /* }}} */
 
-/* {{{ PHP_INI_MH
+/* {{{ PHP_INI_MH(luasandbox_update_allowed_globals)
  */
 static PHP_INI_MH(luasandbox_update_allowed_globals) {
 
@@ -317,7 +324,7 @@ static PHP_INI_MH(luasandbox_update_allowed_globals) {
 		/* Fill up the hashtable . */
 		/* Leave this until php_explode() stops segfaulting.
 		zval * exploded;
-		 array_init( exploded );
+		array_init( exploded );
 		exploded = php_explode( delim, list, exploded, ZEND_LONG_MAX );
 		LUASANDBOX_G(allowed_globals) = *Z_ARRVAL_P(exploded);
 		*/
@@ -325,6 +332,62 @@ static PHP_INI_MH(luasandbox_update_allowed_globals) {
 
 		return SUCCESS;
 	}
+}
+/* }}} */
+
+/* {{{ PHP_INI_MH(luasandbox_update_additional_libraries)
+ */
+static PHP_INI_MH(luasandbox_update_additional_libraries) {
+    if ( new_value != NULL ) {
+		if ( LUASANDBOX_G(additional_libraries).nNumOfElements ) {
+			/* Clean up old values, if any. */
+			zend_hash_destroy( &LUASANDBOX_G(additional_libraries) );
+		}
+		zend_hash_init( &LUASANDBOX_G(additional_libraries), 0, NULL, NULL, 1 );
+		
+		/* Cast new value from php.ini or ini_set() to *char, if necessary. */
+		PCRE2_SPTR list;
+#if PHP_VERSION_ID < 70000
+		list = (PCRE2_SPTR)new_value;
+#else
+		list = (PCRE2_SPTR)ZSTR_VAL(new_value);
+#endif
+		PCRE2_SIZE list_len = (PCRE2_SIZE)strlen( (char *)list );
+
+		PCRE2_SPTR pattern = "(?<lib>[^:=\\s]+)\\s*=\\s*(?<path>[^:\\s]+)";
+		int errornumber;
+		PCRE2_SIZE erroroffset;
+		pcre2_code * re = pcre2_compile(
+			pattern,
+			PCRE2_ZERO_TERMINATED,
+			PCRE2_NEVER_UTF,
+			&errornumber,
+			&erroroffset,
+			NULL
+		);
+		pcre2_match_data * matches = pcre2_match_data_create_from_pattern( re, NULL );
+		PCRE2_SIZE offset = 0;
+		while ( offset < list_len && pcre2_match(re, list, list_len, offset, 0, matches, NULL) > 0 ) {
+			offset = pcre2_get_ovector_pointer( matches )[1];
+			PCRE2_UCHAR * lib;
+			PCRE2_SIZE lib_len;
+			pcre2_substring_get_byname( matches, "lib", &lib, &lib_len );
+			PCRE2_UCHAR * path;
+			PCRE2_SIZE path_len;
+			pcre2_substring_get_byname( matches, "path", &path, &path_len );
+			if ( lib_len && path_len ) {
+				zval path_z;
+				ZVAL_STR(&path_z, zend_string_init(path, path_len, 1));
+				zend_hash_str_add_new( &LUASANDBOX_G(additional_libraries), lib, lib_len, &path_z ); 
+			}
+			pcre2_substring_free( lib );
+			pcre2_substring_free( path );
+		}
+		pcre2_match_data_free( matches );
+		pcre2_code_free( re );
+		return SUCCESS;
+	}
+	return FAILURE;
 }
 /* }}} */
 
@@ -352,6 +415,12 @@ PHP_INI_BEGIN()
 		PHP_LUASANDBOX_INI_ALLOWED_GLOBALS,	"assert,error,getfenv,getmetatable,ipairs,next,pairs,rawequal,rawget,rawset,select,setfenv,setmetatable,tonumber,type,unpack,_G,_VERSION,string,table,math,os,debug",
 		PHP_INI_SYSTEM,
 		luasandbox_update_allowed_globals
+	)
+	PHP_INI_ENTRY(
+		PHP_LUASANDBOX_INI_ADDITIONAL_LIBRARIES,
+		"lpeg=/lib/x86_64-linux-gnu/lua/5.1/lpeg.so:rex_pcre=/lib/x86_64-linux-gnu/lua/5.1/rex_pcre.so",
+		PHP_INI_SYSTEM,
+		luasandbox_update_additional_libraries
 	)
 PHP_INI_END()
 
@@ -433,7 +502,7 @@ static PHP_GINIT_FUNCTION(luasandbox)
 }
 /* }}} */
 
-/** {{{ luasandbox_destroy_globals */
+/** {{{ PHP_GSHUTDOWN_FUNCTION(luasandbox) */
 static PHP_GSHUTDOWN_FUNCTION(luasandbox)
 {
 }
@@ -471,6 +540,14 @@ PHP_MINFO_FUNCTION(luasandbox)
 {
 	php_info_print_table_start();
 	php_info_print_table_header(2, "luasandbox support", "enabled");
+	
+	php_info_print_table_colspan_header( 2, "Additional libraries");
+	zend_string * lib_z;
+	zval * path_z;
+	ZEND_HASH_FOREACH_STR_KEY_VAL(&LUASANDBOX_G(additional_libraries), lib_z, path_z)
+		php_info_print_table_row( 2, ZSTR_VAL(lib_z), Z_STRVAL(*path_z));
+	ZEND_HASH_FOREACH_END();
+
 	php_info_print_table_end();
 }
 /* }}} */
@@ -1998,8 +2075,9 @@ static int LuaSandbox_registerLibrary_protected(lua_State* L) {
 	return 0;
 }
 
-PHP_METHOD(LuaSandbox, registerLibrary)
-{
+/** {{{ LuaSandbox::registerLibrary
+ */
+PHP_METHOD(LuaSandbox, registerLibrary) {
 	struct LuaSandbox_registerLibrary_params p;
 	lua_State * L;
 	int status;
@@ -2027,6 +2105,7 @@ PHP_METHOD(LuaSandbox, registerLibrary)
 		RETVAL_FALSE;
 	}
 }
+
 /** {{{ LuaSandbox::allowedGlobals
  */
 PHP_METHOD(LuaSandbox, allowedGlobals) {
@@ -2046,6 +2125,21 @@ PHP_METHOD(LuaSandbox, allowedGlobals) {
 		php_sprintf( msg, "No globals are allowed. Set %s in php.ini\n", PHP_LUASANDBOX_INI_ALLOWED_GLOBALS );
 		add_next_index_string( return_value, msg );
 	}
+}
+/* }}} */
+
+/** {{{ LuaSandbox::additionalLibraries
+ */
+PHP_METHOD(LuaSandbox, additionalLibraries) {
+#if PHP_VERSION_ID < 70000
+	MAKE_STD_ZVAL(return_value);
+#endif
+	array_init_size( return_value, LUASANDBOX_G(additional_libraries).nNumOfElements );
+	zend_string * lib_z;
+	zval * path_z;
+	ZEND_HASH_FOREACH_STR_KEY_VAL(&LUASANDBOX_G(additional_libraries), lib_z, path_z)
+		add_assoc_string(return_value, ZSTR_VAL(lib_z), Z_STRVAL(*path_z) );
+	ZEND_HASH_FOREACH_END();
 }
 /* }}} */
 

--- a/luasandbox_types.h
+++ b/luasandbox_types.h
@@ -61,6 +61,8 @@ typedef struct {
 ZEND_BEGIN_MODULE_GLOBALS(luasandbox)
 	/* Stored as a value rather than a pointer to avoid segfaults. Inspired by https://github.com/php/php-src/blob/master/ext/pcre/php_pcre.c.*/
 	HashTable allowed_globals;
+	/* A table of additional Lua C libraries. */
+	HashTable additional_libraries;
 	long active_count;
 ZEND_END_MODULE_GLOBALS(luasandbox)
 

--- a/luasandbox_types.h
+++ b/luasandbox_types.h
@@ -61,6 +61,8 @@ typedef struct {
 ZEND_BEGIN_MODULE_GLOBALS(luasandbox)
 	/* Stored as a value rather than a pointer to avoid segfaults. Inspired by https://github.com/php/php-src/blob/master/ext/pcre/php_pcre.c.*/
 	HashTable allowed_globals;
+	/* Lua C libraries loaders. */
+	HashTable library_loaders;
 	/* A table of additional Lua C libraries. */
 	HashTable additional_libraries;
 	long active_count;

--- a/package.xml
+++ b/package.xml
@@ -3,17 +3,17 @@
   <name>LuaSandbox</name>
   <channel>pecl.php.net</channel>
   <summary>Lua interpreter with limits and safe environment</summary>
-  <description>LuaSandbox is an extension for running untrusted Lua code within a PHP web request. Code is run in a stripped-down, safe environment. Time and memory limits can be set.</description>
+  <description>LuaSandbox is an extension for running untrusted Lua code within a PHP web request. Code is run in a stripped-down, safe environment. Time and memory limits can be set. This is a fork created for traditio.wiki</description>
   <lead>
-    <name>Tim Starling</name>
-    <user>tstarling</user>
-    <email>tstarling@wikimedia.org</email>
+    <name>Alexander Mashin</name>
+    <user>mashin</user>
+    <email>alex.mashin@gmail.com</email>
     <active>yes</active>
   </lead>
-  <date>2018-10-11</date>
+  <date>2020-10-02</date>
   <version>
-    <release>3.0.3</release>
-    <api>3.0.3</api>
+    <release>3.1.0</release>
+    <api>3.1.0</api>
   </version>
   <stability>
     <release>stable</release>
@@ -21,7 +21,8 @@
   </stability>
   <license>MIT</license>
   <notes>
-    - Fix ZTS build on PHP 7+ (Patch by Remi Collet)
+    - Add luasandbox.allowed_globals to php.ini and LuaSandbox::allowedGlobals() method
+    - Add luasandbox.additional_libraries to php.ini and LuaSandbox::additionalLibraries() method
   </notes>
   <contents>
     <dir name="/">
@@ -51,6 +52,7 @@
         </dir>
         <file name="book.xml" role="doc"/>
         <file name="configure.xml" role="doc"/>
+        <file name="ini.xml" role="doc"/>
         <file name="constants.xml" role="doc"/>
         <file name="differences.xml" role="doc"/>
         <file name="examples.xml" role="doc"/>
@@ -134,14 +136,14 @@
   <extsrcrelease/>
   <changelog>
     <release>
-      <date>2018-10-09</date>
+      <date>2020-10-02</date>
       <version>
-        <release>3.0.2</release>
-        <api>3.0.2</api>
+        <release>3.1.0</release>
+        <api>3.1.0</api>
       </version>
       <notes>
-        - Fix PHP 7 object layout
-        - Initial PECL release
+	    - Add luasandbox.allowed_globals to php.ini and LuaSandbox::allowedGlobals() method
+	    - Add luasandbox.additional_libraries to php.ini and LuaSandbox::additionalLibraries() method
       </notes>
     </release>
   </changelog>

--- a/php_luasandbox.h
+++ b/php_luasandbox.h
@@ -8,10 +8,10 @@
 #include "luasandbox_types.h"
 #include "luasandbox_timer.h"
 
-/* alloc.c */
-
 #define PHP_LUASANDBOX_INI_ALLOWED_GLOBALS "luasandbox.allowed_globals"
+#define PHP_LUASANDBOX_INI_ADDITIONAL_LIBRARIES "luasandbox.additional_libraries"
 
+/* alloc.c */
 lua_State * luasandbox_alloc_new_state(php_luasandbox_alloc * alloc, php_luasandbox_obj * sandbox);
 void luasandbox_alloc_delete_state(php_luasandbox_alloc * alloc, lua_State * L);
 
@@ -63,7 +63,7 @@ PHP_METHOD(LuaSandbox, callFunction);
 PHP_METHOD(LuaSandbox, wrapPhpFunction);
 PHP_METHOD(LuaSandbox, registerLibrary);
 PHP_METHOD(LuaSandbox, allowedGlobals);
-
+PHP_METHOD(LuaSandbox, additionalLibraries);
 PHP_METHOD(LuaSandboxFunction, __construct);
 PHP_METHOD(LuaSandboxFunction, call);
 PHP_METHOD(LuaSandboxFunction, dump);


### PR DESCRIPTION
Add `luasandbox.additional_libraries` to `php.ini` and `LuaSandbox::additionalLibraries()` method
`
luasandbox.additional_libraries` can be used to load additional Lua C libraries,
in the following form:
`lib1=absolute path to .so file 1:lib2=absolute path to .so file 2`,
e.g. `rex_pcre=/usr/lib/x86_64-linux-gnu/lua/5.1/rex_pcre.so` means that PHP engine
will attempt to load `/usr/lib/x86_64-linux-gnu/lua/5.1/rex_pcre.so` library,
call the initialization function `luaopen_rex_pcre()` and make the library available
under global name `rex_pcre`.

`LuaSandbox::additionalLibraries()` returns a numbered array list of global Lua names
of successfully loaded additional Lua C libraries.

Change-Id: I7c236a70e79a235d3ef53f24b1b9357a75ed10f1